### PR TITLE
Fix 'start at cwd for the rest' test on win32

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,7 @@
 Revision history for Sys-Path
+0.14    6 Feb 2015
+        - use File::Spec->canonpath to pass the cwd test on win32 paltforms
+        - mantain the same version in all packages (cpants);
 
 0.13    18 Apr 2013
         - add note before promting users during distribution installation

--- a/lib/Sys/Path.pm
+++ b/lib/Sys/Path.pm
@@ -3,7 +3,7 @@ package Sys::Path;
 use warnings;
 use strict;
 
-our $VERSION = '0.13';
+our $VERSION = '0.14';
 
 use File::Spec;
 use Text::Diff 'diff';

--- a/lib/Sys/Path/SPc.pm
+++ b/lib/Sys/Path/SPc.pm
@@ -3,7 +3,7 @@ package Sys::Path::SPc;
 use warnings;
 use strict;
 
-our $VERSION = '0.12';
+our $VERSION = '0.14';
 
 use File::Spec;
 

--- a/t/01_Sys-Path.t
+++ b/t/01_Sys-Path.t
@@ -55,7 +55,7 @@ sub main {
     like(Sys::Path->find_distribution_root('TestDR::build'), qr/v1$/, 'find_distribution_root()');
     like(Sys::Path->find_distribution_root('TestDR::makefile'), qr/v2$/, 'find_distribution_root()');
     like(Sys::Path->find_distribution_root('TestDR::F::F2::t'), qr/v3$/, 'find_distribution_root()');
-    is(Sys::Path->find_distribution_root('TestDR::non-existing'), cwd, 'start at cwd for the rest');
+    is(Sys::Path->find_distribution_root('TestDR::non-existing'), File::Spec->canonpath(cwd), 'start at cwd for the rest');
     
     my $prompt_reply;
     my $output = capture_merged {


### PR DESCRIPTION
fix tests comparing canonical paths 
increase version number to 0.14 in both Sys::Path and Sys::Path::SPc