### PR TITLE
use List::Util for `any` and `none` instead of List::MoreUtils

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -18,7 +18,7 @@ my $builder = inc::MyBuilder->new(
     },
     requires => {
         'File::Spec'      => 0,
-        'List::MoreUtils' => 0,
+        'List::Util'      => '1.33',
         'Text::Diff'      => 0,
         'JSON::Util'      => 0,
         'Digest::MD5'     => 0,

--- a/lib/Sys/Path.pm
+++ b/lib/Sys/Path.pm
@@ -9,7 +9,7 @@ use File::Spec;
 use Text::Diff 'diff';
 use JSON::Util;
 use Digest::MD5 qw(md5_hex);
-use List::MoreUtils 'any', 'none';
+use List::Util 'any', 'none';
 use Carp 'croak', 'confess';
 use Cwd 'cwd';
 


### PR DESCRIPTION
Suggestion: use `List::Util` for `any` and `none` instead of `List::MoreUtils`.  The former comes bundled with Perl and as of version 1.33 includes both `any` and `none`.